### PR TITLE
Enable toggling of all-selected-items display

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@vaadin/vaadin-material-styles": "1.3.2",
     "@vaadin/vaadin-rich-text-editor": "1.3.0",
     "lit-element": "2.3.1",
-    "@vaadin-component-factory/vcf-multi-select": "^1.1.0",
+    "@vaadin-component-factory/vcf-multi-select": "^1.2.0",
     "@vaadin/router": "1.7.2",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/form": "./target/flow-frontend/form"
@@ -117,7 +117,7 @@
       "@vaadin/vaadin-material-styles": "1.3.2",
       "@vaadin/vaadin-rich-text-editor": "1.3.0",
       "lit-element": "2.3.1",
-      "@vaadin-component-factory/vcf-multi-select": "^1.1.0",
+      "@vaadin-component-factory/vcf-multi-select": "^1.2.0",
       "@vaadin/router": "1.7.2"
     },
     "devDependencies": {
@@ -140,6 +140,6 @@
       "html-webpack-plugin": "3.2.0",
       "typescript": "3.8.3"
     },
-    "hash": "384fb24eb9e77c2305fc59111785d3df63f12b90905d801d8dda863bd2a91051"
+    "hash": "7936eb371aafa60042cabc6b8098473000a37d8c272aa0ea5aec41f330f18e32"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ dependencies:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
-  '@vaadin-component-factory/vcf-multi-select': 1.1.0
+  '@vaadin-component-factory/vcf-multi-select': 1.2.0
   '@vaadin/flow-frontend': 'link:target/flow-frontend'
   '@vaadin/form': 'link:target/flow-frontend/form'
   '@vaadin/router': 1.7.2
@@ -1146,7 +1146,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==
-  /@vaadin-component-factory/vcf-multi-select/1.1.0:
+  /@vaadin-component-factory/vcf-multi-select/1.2.0:
     dependencies:
       '@polymer/iron-media-query': 3.0.1
       '@polymer/iron-resizable-behavior': 3.0.1
@@ -1164,7 +1164,7 @@ packages:
       '@vaadin/vaadin-themable-mixin': 1.6.1
     dev: false
     resolution:
-      integrity: sha512-osty50jPz1na7atf+/uZrL37vUF8grBEGQgwHlFOmFRV8oR4vN3YXruShpAUrg/iXEG19IQ8nH7EkRw1sE4hAA==
+      integrity: sha512-4atEGErnCQXsOOVB5pajM0+6kmGTdrj/lU1AK5Sy/kT1bHqrBK9hDYE9jTNKlCJ9QQ+WY0PESQWSNCSy8qdeqQ==
   /@vaadin/router/1.7.2:
     dependencies:
       '@vaadin/vaadin-usage-statistics': 2.1.0
@@ -6794,7 +6794,7 @@ specifiers:
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
   '@types/validator': 10.11.3
-  '@vaadin-component-factory/vcf-multi-select': ^1.1.0
+  '@vaadin-component-factory/vcf-multi-select': ^1.2.0
   '@vaadin/flow-frontend': ./target/flow-frontend
   '@vaadin/form': ./target/flow-frontend/form
   '@vaadin/router': 1.7.2

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>multiple-select</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <name>Multiple Select</name>
     <description>Integration of vcf-multi-select for Vaadin platform</description>
 

--- a/src/main/java/com/vaadin/componentfactory/MultipleSelect.java
+++ b/src/main/java/com/vaadin/componentfactory/MultipleSelect.java
@@ -362,6 +362,46 @@ public class MultipleSelect<T>
 
     /**
      * <p>
+     * When true, it indicates that all selected items will be shown
+     * comma-separated (with ellipsis if more items are present than fits the
+     * component).
+     * <p>
+     * If false, it indicates that after the first selected item, additional
+     * selected items will be abbreviated (showing only the number of
+     * additionally selected items between brackets).
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
+     *
+     * @return the {@code displayAllSelected} property from the webcomponent
+     */
+    @Override
+    public boolean isDisplayAllSelected() {
+        return super.isDisplayAllSelected();
+    }
+
+    /**
+     * <p>
+     * If set to true, all selected items will be shown comma-separated (with
+     * ellipsis if more items are present than fits the component).
+     *
+     * When set to false (default), it indicates that after the first selected
+     * item, additional selected items will be abbreviated (showing only the
+     * number of additionally selected items between brackets).
+     * </p>
+     *
+     * @param displayAllSelected
+     *            the boolean value to set
+     * @see #setExtraItemsCountText()
+     */
+    @Override
+    public void setDisplayAllSelected(boolean displayAllSelected) {
+        super.setDisplayAllSelected(displayAllSelected);
+    }
+
+    /**
+     * <p>
      * Gets the texts shown after the count when more than a single item is
      * selected.
      * </p>
@@ -378,12 +418,17 @@ public class MultipleSelect<T>
      * <p>
      * Sets the text shown after the count when more than a single item is
      * selected.
+     * <p>
+     * Note that setting the text will have any effect only if the component's
+     * {@code display-all-selected} attribute is present (which can be toggled
+     * using {@code setDisplayAllSelected(true/false)}).
      * </p>
      *
      * @param singularString
      *            the text shown when only on extra item is selected.
      * @param pluralString
      *            the text shown when two or more extra items selected.
+     * @see #setDisplayAllSelected(boolean displayAllSelected)
      */
     @Override
     public void setExtraItemsCountText(String singularString,

--- a/src/main/java/com/vaadin/componentfactory/MultipleSelectBase.java
+++ b/src/main/java/com/vaadin/componentfactory/MultipleSelectBase.java
@@ -16,11 +16,10 @@ import com.vaadin.flow.shared.Registration;
 
 @Tag("vcf-multi-select")
 @JavaScript("@vaadin-component-factory/vcf-multi-select/src/vcf-multi-select.js")
-@NpmPackage(value = "@vaadin-component-factory/vcf-multi-select", version = "^1.1.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-multi-select", version = "^1.2.0")
 public abstract class MultipleSelectBase<C extends MultipleSelectBase<C, T, V>, T, V>
         extends AbstractSinglePropertyField<C, V>
         implements HasStyle, Focusable<C> {
-
 
     /**
      * <p>
@@ -291,19 +290,61 @@ public abstract class MultipleSelectBase<C extends MultipleSelectBase<C, T, V>, 
     protected void setReadonly(boolean readonly) {
         getElement().setProperty("readonly", readonly);
     }
-    
+
     /**
      * <p>
-     * Sets the text shown after the count when more than a single item is selected.
+     * When true, it indicates that all selected items will be shown
+     * comma-separated (with ellipsis if more items are present than fits the
+     * component).
+     * <p>
+     * If false, it indicates that after the first selected item, additional
+     * selected items will be abbreviated (showing only the number of
+     * additionally selected items between brackets).
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
+     *
+     * @return the {@code displayAllSelected} property from the webcomponent
+     */
+    protected boolean isDisplayAllSelected() {
+        return getElement().getProperty("displayAllSelected", false);
+    }
+
+    /**
+     * <p>
+     * If set to true, all selected items will be shown comma-separated (with
+     * ellipsis if more items are present than fits the component).
+     *
+     * When set to false (default), it indicates that after the first selected
+     * item, additional selected items will be abbreviated (showing only the
+     * number of additionally selected items between brackets).
+     * </p>
+     *
+     * @param displayAllSelected
+     *            the boolean value to set
+     * @see #setExtraItemsCountText()
+     */
+    protected void setDisplayAllSelected(boolean displayAllSelected) {
+        getElement().setProperty("displayAllSelected", displayAllSelected);
+    }
+
+    /**
+     * <p>
+     * Sets the text shown after the count when more than a single item is
+     * selected.
      * </p>
      *
      * @param singularString
      *            the text shown when only on extra item is selected.
      * @param pluralString
      *            the text shown when two or more extra items selected.
+     * @see #setDisplayAllSelected(boolean displayAllSelected)
      */
-    protected void setExtraItemsCountText(String singularString, String pluralString) {
-        getElement().executeJs("this.setExtraItemsCountText($0, $1);", singularString, pluralString);
+    protected void setExtraItemsCountText(String singularString,
+            String pluralString) {
+        getElement().executeJs("this.setExtraItemsCountText($0, $1);",
+                singularString, pluralString);
     }
 
     /**
@@ -444,16 +485,12 @@ public abstract class MultipleSelectBase<C extends MultipleSelectBase<C, T, V>, 
      * @param <P>
      *            the property type
      */
-    public <P> MultipleSelectBase(String propertyName,
-            V defaultValue, Class<P> elementPropertyType,
+    public <P> MultipleSelectBase(String propertyName, V defaultValue,
+            Class<P> elementPropertyType,
             SerializableBiFunction<C, P, V> presentationToModel,
             SerializableBiFunction<C, V, P> modelToPresentation) {
         super(propertyName, defaultValue, elementPropertyType,
                 presentationToModel, modelToPresentation);
     }
-
-
-
-
 
 }

--- a/src/test/java/com/vaadin/componentfactory/MultipleSelectView.java
+++ b/src/test/java/com/vaadin/componentfactory/MultipleSelectView.java
@@ -1,19 +1,70 @@
 package com.vaadin.componentfactory;
 
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
 @Route("")
-public class MultipleSelectView extends Div {
+public class MultipleSelectView extends VerticalLayout {
 
     public MultipleSelectView() {
         MultipleSelect<String> multipleSelect = new MultipleSelect<>();
-        multipleSelect.setItems("Jose", "Manolo", "Pedro");
+        multipleSelect.setItems("Jose", "Manolo", "Pedro", "Luis");
 
         multipleSelect.setLabel("MultipleSelect");
         multipleSelect.setPlaceholder("Select multiple items");
-        multipleSelect.setWidth("25%");
+        multipleSelect.setWidth("200px");
 
         add(multipleSelect);
+
+        add(new Span("Toggle DisplayAllSelected:"), new Button(
+                "Toggle DisplayAllSelected",
+                e -> multipleSelect.setDisplayAllSelected(
+                !multipleSelect.isDisplayAllSelected())));
+
+        HorizontalLayout extraItemsAdjustLayout = getExtraItemsAdjustLayout(
+                multipleSelect);
+        add(extraItemsAdjustLayout);
+
+        HorizontalLayout widthAdjustLayout = getWidthAdjustLayout(
+                multipleSelect);
+        add(widthAdjustLayout);
+    }
+
+    private HorizontalLayout getExtraItemsAdjustLayout(
+            MultipleSelect<String> multipleSelect) {
+        TextField singularString = new TextField("Singular String");
+        singularString.setValue("other");
+        TextField pluralString = new TextField("Plural String");
+        pluralString.setValue("others");
+        Button setExtraItemsCountText = new Button("Set ExtraItemsCountText",
+                e -> multipleSelect.setExtraItemsCountText(
+                        singularString.getValue(), pluralString.getValue()));
+
+        HorizontalLayout extraItemsAdjustLayout = new HorizontalLayout(
+                singularString, pluralString, setExtraItemsCountText);
+        extraItemsAdjustLayout
+                .setDefaultVerticalComponentAlignment(Alignment.END);
+        return extraItemsAdjustLayout;
+    }
+
+    private HorizontalLayout getWidthAdjustLayout(
+            MultipleSelect<String> multipleSelect) {
+        IntegerField width = new IntegerField("Width (in pixels)");
+        width.setValueChangeMode(ValueChangeMode.ON_CHANGE);
+        width.setValue(200);
+        width.setMin(0);
+        Button setWidth = new Button("Set width",
+                e -> multipleSelect.setWidth(width.getValue() + "px"));
+
+        HorizontalLayout widthAdjustLayout = new HorizontalLayout(width,
+                setWidth);
+        widthAdjustLayout.setDefaultVerticalComponentAlignment(Alignment.END);
+        return widthAdjustLayout;
     }
 }


### PR DESCRIPTION
By default, only the first selected value is displayed in the field, with the number of additionally selected values (N) is indicated as "(+N other(s))".

This PR adds the possibility of changing this behavior by setting the displayAllSelected property to true, in which case all selected items will be displayed, comma-separated, with ellipsis if more items are present than fits the component.